### PR TITLE
skip symlinks for correct handling of Qt Frameworks

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
 
         QFileInfo fileInfo(it.filePath());
 
-        if (fileInfo.isDir())
+        if (fileInfo.isDir() || fileInfo.isSymLink())
             continue;
 
         QString x86_64File = it.filePath();


### PR DESCRIPTION
symlinks must be skipped for correct handling of Qt frameworks.
Otherwise it replaces symlinks with original files and the binary couldn't be signed resulting:

`bundle format is ambiguous (could be app or framework)`

Now it works faster of cause too 😄 